### PR TITLE
Add support for fetching multiple PVs from archiver

### DIFF
--- a/lib/src/main/java/org/epics/archiverappliance/retrieval/client/DataRetrieval.java
+++ b/lib/src/main/java/org/epics/archiverappliance/retrieval/client/DataRetrieval.java
@@ -8,13 +8,15 @@
 package org.epics.archiverappliance.retrieval.client;
 
 import java.sql.Timestamp;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
  * Main interface for client retrieving data using the PB/HTTP protocol.
  * @author mshankar
  */
-public interface DataRetrieval {
+public abstract class DataRetrieval {
     /**
      * Get data for PV pvName from starttime to endtime. By default, we expect to get raw data.
      * @param pvName The name of the pv
@@ -22,7 +24,9 @@ public interface DataRetrieval {
      * @param endTime End time of request
      * @return Return an iterator over the data.
      */
-    public GenMsgIterator getDataForPV(String pvName, Timestamp startTime, Timestamp endTime);
+    public final GenMsgIterator getDataForPV(String pvName, Timestamp startTime, Timestamp endTime) {
+        return getDataForPV(pvName, startTime, endTime, false);
+    };
     /**
      * Get data for PV pvName from starttime to endtime using the system defined sparsification operator.
      * @param pvName The name of the pv
@@ -31,8 +35,10 @@ public interface DataRetrieval {
      * @param useReducedDataSet - If true, use the server defined sparsification operator...
      * @return Return an iterator over the data.
      */
-    public GenMsgIterator getDataForPV(
-            String pvName, Timestamp startTime, Timestamp endTime, boolean useReducedDataSet);
+    public final GenMsgIterator getDataForPV(
+            String pvName, Timestamp startTime, Timestamp endTime, boolean useReducedDataSet) {
+                return getDataForPV(pvName, startTime, endTime, useReducedDataSet, null);
+            }
 
     /**
      * Get data for PV pvName from starttime to endtime using the system defined sparsification operator; pass additional params in the HTTP call.
@@ -43,8 +49,28 @@ public interface DataRetrieval {
      * @param otherParams - Any other name/value pairs that are passed onto the server.
      * @return Return an iterator over the data.
      */
-    public GenMsgIterator getDataForPV(
+    public final GenMsgIterator getDataForPV(
             String pvName,
+            Timestamp startTime,
+            Timestamp endTime,
+            boolean useReducedDataSet,
+            Map<String, String> otherParams) {
+                return getDataForPVs(Collections.singletonList(pvName), startTime, endTime, useReducedDataSet, otherParams);
+            }
+
+    /**
+     * Get data for PVs in pvNames from starttime to endtime using the system defined sparsification operator; pass additional params in the HTTP call.
+     * NOTE: The data for all the PVs will be concatenated together. To identify which PV is currently being read, you must register your own 
+     * {@code InfoChangeHandler} to the returned {@code GenMsgIterator} using {@code onInfoChange}.
+     * @param pvName The name of the pv
+     * @param startTime Start time of request
+     * @param endTime End time of request
+     * @param useReducedDataSet - If true, use the server defined sparsification operator...
+     * @param otherParams - Any other name/value pairs that are passed onto the server.
+     * @return Return an iterator over the data.
+     */
+    public abstract GenMsgIterator getDataForPVs(
+            List<String> pvNames,
             Timestamp startTime,
             Timestamp endTime,
             boolean useReducedDataSet,


### PR DESCRIPTION
* change DataRetrieval abstract base class to have method for fetching multiple pvs
* modify RawDataRetrieval to use multiple PV query parameters

The purpose of this PR is to allow fetching multiple PV time series. This is particulary relevant for the save-restore phoebus feature which wants to retrieve multiple time series at a time. (Note confusingly the archiver appliance "save-restore" feature is unsuitable due to json being the only format returned, and we would like to use protobuf for consistency reasons). The interface itself is a little awkward, the different PV values are delivered contiguously and the user must create another class to parse the delinations. But this was the most natural option to integrate with the existing code.